### PR TITLE
Add redirection feature from datalad handbook

### DIFF
--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -94,4 +94,5 @@ Appendix
 
    website_info
    content_pages/website_info
+   r
 

--- a/docs/r.rst
+++ b/docs/r.rst
@@ -1,0 +1,65 @@
+Redirection
+-----------
+
+This page exists for redirection purposes only.
+
+..
+   Include a named paragraph in the page, where the javascript code below will
+   place any message.
+
+.. raw:: html
+
+   <p><strong id="successmessage">
+     You will be redirected to your target page in a few seconds.
+   </strong></p>
+
+..
+   use a custom role to identify redirect codes so that a bit of JS can find
+   them again
+
+.. role:: redirect
+   :class: redirect
+
+If you continue to see this page, you've ended up in here accidentally and redirection
+failed -- sorry about this.
+
+**Here are some links that may take you to where you need to go:**
+
+..
+   This defines a mapping of redirect codes to their present URLs.
+   Please keep sorted by redirection label.
+
+:redirect:`openneuro`
+  :ref:`openNeuro`
+
+Alternatively, try searching in the "Quick Search" at the left-hand side, or
+scan the handbook's front page at `brainhack-princeton.github.io/handbook <https://brainhack-princeton.github.io/handbook/>`_ for directions.
+
+..
+   This code replaces the r.html?key part with the final URL, while keeping
+   the rest of URL intact.
+
+.. raw:: html
+
+   <script>
+   // take everything after "?" as a code to identify the redirect
+   redirect_code = window.location.href.replace(/.*\?/, "");
+   success = false;
+   // loop over all redirect definitions (see above)
+   for (rd of document.getElementsByClassName('redirect')){
+     if (rd.innerText != redirect_code) {continue;}
+     // read the href from the link in the <dd> matching the <dt> of the redirect
+     // this assumes a very simple, and particular structure
+     // let's hope that sphinx doesn't break it
+     target = rd.parentElement.nextElementSibling.getElementsByTagName("a")[0].href;
+     // and jump
+     window.location.replace(target);
+     success = true;
+     break;
+   }
+   // if we get here, we didn't find a match
+   if (success == false) {
+     document.getElementById("successmessage"
+       ).innerHTML = "Whoops - redirection went wrong, we are lost!"
+   }
+   </script>


### PR DESCRIPTION
Hi :wave:! 

I'm proposing a feature we are using at the DataLad Handbook to distribute stable URLs.
Instead of relying on unchanged file names and directories, this allows to reference a page via its reference handle (e.g., ``.. _openNeuro:``) as a redirection. 

The page works like this: It is a normal rst file, and becomes an actual page of the handbook.
Any key in ``:redirect:`value` `` can be added to a URL following this pattern:

> brainhack-princeton.github.io/handbook/r.html?value

The URL will redirect to the page associated with ``:ref:`value` ``. I have included a redirection for the first page in the PR. With it, you should be able to visit http://brainhack-princeton.github.io/handbook/r.html?openneuro and get redirected to https://brainhack-princeton.github.io/handbook/content_pages/01-01-openNeuro.html. If a non-linked value would be used (say,a typo like ``opneneuro``) the page displays a "redirection went wrong" and lists all existing configured redirections (visit for example http://handbook.datalad.org/r.html?gibberish for a demo of this in the datalad handbook).

We use this "hack" to safeguard important pages that are linked somewhere else against file name changes or restructuring (the only thing that is not allowed to change are the reference handles of the  pages or sections), and I thought that this may be useful for you, too :)